### PR TITLE
Deprecated mqtt sensor configuration

### DIFF
--- a/docs/haconfig/.mqtt.yaml
+++ b/docs/haconfig/.mqtt.yaml
@@ -1,0 +1,81 @@
+# Consumption
+sensor:
+-   name: "VMC Power Current"
+    state_topic: "comfoair/power_consumption_current"
+    unit_of_measurement: W
+
+-   name: "VMC Total Energy Saving"
+    state_topic: "comfoair/ah_ytd"
+    unit_of_measurement: Wh
+
+# FAns
+
+
+-   name: "VMC Exhaust Fan Speed"
+    state_topic: "comfoair/exhaust_fan_speed"
+    unit_of_measurement: rpm
+
+-   name: "VMC Supply Fan Speed"
+    state_topic: "comfoair/supply_fan_speed"
+    unit_of_measurement: rpm
+
+-   name: "VMC Exhaust Fan Duty"
+    state_topic: "comfoair/exhaust_fan_duty"
+    unit_of_measurement: rpm
+
+-   name: "VMC Supply Fan Duty"
+    state_topic: "comfoair/supply_fan_duty"
+    unit_of_measurement: rpm
+
+-   name: "VMC Supply Fan User Speed"
+    state_topic: "comfoair/fan_speed"
+
+  # FLOW
+
+-   name: "VMC Exhaust Fan Flow"
+    state_topic: "comfoair/exhaust_fan_flow"
+    unit_of_measurement: "m³/h"
+
+-   name: "VMC Supply Fan Flow"
+    state_topic: "comfoair/supply_fan_flow"
+    unit_of_measurement: "m³/h"
+
+# TEMPS
+
+-   name: "VMC Outdoor Air Temperature"
+    state_topic: "comfoair/outdoor_air_temp"
+    unit_of_measurement: "°C"
+
+-   name: "VMC Exhaust Air Temperature"
+    state_topic: "comfoair/exhaust_air_temp"
+    unit_of_measurement: "°C"
+
+-   name: "VMC Extract Air Temperature"
+    state_topic: "comfoair/extract_air_temp"
+    unit_of_measurement: "°C"
+
+-   name: "VMC Post Heater Temp Before"
+    state_topic: "comfoair/post_heater_temp_before"
+    unit_of_measurement: "°C"
+
+-   name: "VMC Post Heater Temp After"
+    state_topic: "comfoair/post_heater_temp_after"
+    unit_of_measurement: "°C"
+
+# Humidity
+
+-   name: "VMC Outdoor Air Humidity"
+    state_topic: "comfoair/outdoor_air_humidity"
+    unit_of_measurement: "%"
+
+-   name: "VMC Exhaust Air Humidity"
+    state_topic: "comfoair/exhaust_air_humidity"
+    unit_of_measurement: "%"
+
+-   name: "VMC Extract Air Humidity"
+    state_topic: "comfoair/extract_air_humidity"
+    unit_of_measurement: "%"
+
+-   name: "VMC Supply Air Humidity"
+    state_topic: "comfoair/supply_air_humidity"
+    unit_of_measurement: "%"


### PR DESCRIPTION
Including mqtt sensors as sensor-platform:mqtt is no more working in last HA releases. Here is a fix, to be included as mqtt: !include .mqtt.yaml